### PR TITLE
VideoRenderer: don't preload the entire video

### DIFF
--- a/src/hooks/useDocumentLoader.ts
+++ b/src/hooks/useDocumentLoader.ts
@@ -29,6 +29,7 @@ export const useDocumentLoader = (): {
 
   const documentURI = currentDocument?.uri || "";
 
+  // Sniff contentType using HEAD fetch
   useEffect(
     () => {
       if (!currentDocument) return;
@@ -69,6 +70,8 @@ export const useDocumentLoader = (): {
     [currentFileNo, documentURI, currentDocument],
   );
 
+  // File changed and/or renderer changed:
+  // fetch entire file and update current document
   useEffect(() => {
     if (!currentDocument || CurrentRenderer === undefined) return;
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -3,79 +3,80 @@ import { IMainState } from "./store/mainStateReducer";
 import { FileLoaderFunction } from "./utils/fileLoaders";
 
 export interface IConfig {
-  header?: IHeaderConfig;
-  loadingRenderer?: ILoadingRendererConfig;
-  noRenderer?: INoRendererConfig;
-  csvDelimiter?: string;
-  pdfZoom?: IPdfZoomConfig;
-  pdfVerticalScrollByDefault?: boolean;
+  header?: IHeaderConfig
+  loadingRenderer?: ILoadingRendererConfig
+  noRenderer?: INoRendererConfig
+  csvDelimiter?: string
+  pdfZoom?: IPdfZoomConfig
+  pdfVerticalScrollByDefault?: boolean
 }
 
 export interface ILoadingRendererConfig {
   overrideComponent?: ComponentType<{
-    document: IDocument | undefined;
-    fileName: string;
+    document: IDocument | undefined
+    fileName: string
   }>;
-  showLoadingTimeout?: false | number;
+  showLoadingTimeout?: false | number
 }
 
 export interface INoRendererConfig {
   overrideComponent?: ComponentType<{
-    document: IDocument | undefined;
-    fileName: string;
+    document: IDocument | undefined
+    fileName: string
   }>;
 }
 
 export interface IHeaderConfig {
-  disableHeader?: boolean;
-  disableFileName?: boolean;
-  retainURLParams?: boolean;
-  overrideComponent?: IHeaderOverride;
+  disableHeader?: boolean
+  disableFileName?: boolean
+  retainURLParams?: boolean
+  overrideComponent?: IHeaderOverride
 }
 
 export interface IPdfZoomConfig {
-  defaultZoom: number;
-  zoomJump: number;
+  defaultZoom: number
+  zoomJump: number
 }
 
 export type IHeaderOverride = (
   state: IMainState,
   previousDocument: () => void,
   nextDocument: () => void,
-) => ReactElement<any, any> | null;
+) => ReactElement<any, any> | null
 
 export interface ITheme {
-  primary?: string;
-  secondary?: string;
-  tertiary?: string;
-  textPrimary?: string;
-  textSecondary?: string;
-  textTertiary?: string;
-  disableThemeScrollbar?: boolean;
+  primary?: string
+  secondary?: string
+  tertiary?: string
+  textPrimary?: string
+  textSecondary?: string
+  textTertiary?: string
+  disableThemeScrollbar?: boolean
 }
 
 export interface IStyledProps {
-  theme: ITheme;
+  theme: ITheme
 }
 
 export interface IDocument {
   uri: string;
-  fileType?: string;
-  fileData?: string | ArrayBuffer;
-  fileName?: string;
+  fileType?: string
+  fileData?: string | ArrayBuffer
+  fileName?: string
 }
 
 export interface DocRendererProps {
-  mainState: IMainState;
+  mainState: IMainState
 }
 
 export interface DocRenderer extends FC<PropsWithChildren<DocRendererProps>> {
-  fileTypes: string[];
-  weight: number;
-  fileLoader?: FileLoaderFunction | null | undefined;
+  fileTypes: string[]
+  weight: number
+  fileLoader?: FileLoaderFunction | null | undefined
+  streaming?: boolean
 }
 
 export interface DocViewerRef {
-  prev: () => void;
-  next: () => void;
+  prev: () => void
+  next: () => void
 }

--- a/src/renderers/video/index.tsx
+++ b/src/renderers/video/index.tsx
@@ -1,21 +1,28 @@
-import React from "react";
-import styled from "styled-components";
-import { DocRenderer } from "../..";
+import React from "react"
+import styled from "styled-components"
+import { DocRenderer } from "../.."
 
 const VideoRenderer: DocRenderer = ({ mainState: { currentDocument } }) => {
-  if (!currentDocument) return null;
+  if (!currentDocument) return null
 
   return (
     <Container id="video-renderer">
-      <Video controls src={currentDocument.uri} />
+      <Video controls src={currentDocument.uri} autoPlay />
     </Container>
   );
 };
 
-export default VideoRenderer;
+export default VideoRenderer
 
-VideoRenderer.fileTypes = ["video/mp4", "video/quicktime", "video/x-msvideo"];
-VideoRenderer.weight = 0;
+VideoRenderer.fileTypes = ["video/mp4", "video/quicktime", "video/x-msvideo"]
+VideoRenderer.weight = 0
+// Define a fake file loader for videos: the video tag will automatically stream
+// the video so we don't need to load the whole (!) file before.
+VideoRenderer.fileLoader = ({ fileLoaderComplete }) => {
+  fileLoaderComplete({
+    result: null
+  } as FileReader)
+}
 
 const Container = styled.div`
   width: 100%;


### PR DESCRIPTION
This was done by adding a fake fileLoader for the video Renderer that completes immediately.