### PR TITLE
PDFSinglePage: removed useless last prop

### DIFF
--- a/src/renderers/pdf/components/pages/PDFSinglePage.tsx
+++ b/src/renderers/pdf/components/pages/PDFSinglePage.tsx
@@ -20,7 +20,7 @@ const PDFSinglePage: FC<Props> = ({ pageNum }) => {
   const _pageNum = pageNum || currentPage;
 
   return (
-    <PageWrapper id="pdf-page-wrapper" last={_pageNum >= numPages}>
+    <PageWrapper id="pdf-page-wrapper">
       {!paginated && (
         <PageTag id="pdf-page-info">
           {t("pdfPluginPageNumber", {


### PR DESCRIPTION
This doesn't belong to div tag and was generating React errors.