### PR TITLE
useDocumentLoader: hide loading if fetch fails

### DIFF
--- a/src/components/ProxyRenderer.tsx
+++ b/src/components/ProxyRenderer.tsx
@@ -51,9 +51,11 @@ type ContentsProps = {
     } else {
       if (CurrentRenderer) {
         return <CurrentRenderer mainState={state} />;
-      } else if (CurrentRenderer === undefined) {
-        return null;
       } else {
+        // we get here if:
+        // - there was a problem fetching the file type (access denied, cors errors,..)
+        // - there is no rednderer for current file type
+        // in *both* cases we want to show the no Renderer component
         if (config && config?.noRenderer?.overrideComponent) {
           const OverrideComponent = config.noRenderer.overrideComponent;
           return (

--- a/src/hooks/useDocumentLoader.ts
+++ b/src/hooks/useDocumentLoader.ts
@@ -58,8 +58,13 @@ export const useDocumentLoader = (): {
         })
         .catch((error) => {
           if (error?.name !== "AbortError") {
+            // Don't get stuck with the loading component
+            // if we can't fetch the filetype: we'll show
+            // the no renderer component instead
+            dispatch(setDocumentLoading(false));
             throw error;
           }
+
         });
 
       return () => {
@@ -73,7 +78,8 @@ export const useDocumentLoader = (): {
   // File changed and/or renderer changed:
   // fetch entire file and update current document
   useEffect(() => {
-    if (!currentDocument || CurrentRenderer === undefined) return;
+    if (!currentDocument || CurrentRenderer === undefined)
+      return
 
     const controller = new AbortController();
     const { signal } = controller;

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -64,7 +64,8 @@ export const previousDocument = (): PreviousDocument => ({
 
 export const updateCurrentDocument = (
   document: IDocument,
-): UpdateCurrentDocument => ({ type: UPDATE_CURRENT_DOCUMENT, document });
+): UpdateCurrentDocument => ({ type: UPDATE_CURRENT_DOCUMENT, document })
+
 
 export const setRendererRect = (rect: DOMRect): SetRendererRect => ({
   type: SET_RENDERER_RECT,


### PR DESCRIPTION
This fixes the endless loading screen. Also, display the NoRenderer component in this case too.