### PR TITLE
react-pdf: include pdf.worker.min.js in build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,3 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .idea
-
-# pdf worker: this fill must be fetched after each installation since it depends
-# on react-pdf's embdeded version
-src/pdf.worker.min.js

--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
   },
   "scripts": {
     "start": "storybook dev -p 6006",
-    "build": "rm -rf dist && npm run build:esm && npm run build:cjs",
+    "build": "rm -rf dist && npm run build:esm && npm run build:cjs && npm run copy-worker",
     "build:esm": "tsc --noEmit false",
     "build:cjs": "tsc --noEmit false --module commonjs --outDir ./dist/cjs",
+    "copy-worker": "cp ./node_modules/react-pdf/node_modules/pdfjs-dist/build/pdf.worker.min.js dist/",
     "test": "react-scripts test --watchAll=false",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",

--- a/src/renderers/pdf/index.tsx
+++ b/src/renderers/pdf/index.tsx
@@ -4,16 +4,13 @@ import styled from "styled-components";
 import { DocRenderer, IStyledProps } from "../..";
 import PDFPages from "./components/pages/PDFPages";
 import PDFControls from "./components/PDFControls";
-import { PDFContext, PDFProvider } from "./state";
+import { PDFProvider } from "./state";
 import "react-pdf/dist/esm/Page/AnnotationLayer.css";
 import "react-pdf/dist/esm/Page/TextLayer.css";
 
-// react-explorer
-pdfjs.GlobalWorkerOptions.workerSrc = 'pdf.worker.min.js'
-// original
-// pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.js`;
+pdfjs.GlobalWorkerOptions.workerSrc = './pdf.worker.min.js'
 
-const PDFRenderer: DocRenderer = ({ mainState }) => {
+const PDFRenderer: DocRenderer = () => {
   return (
     <PDFProvider>
       <Container id="pdf-renderer" data-testid="pdf-renderer">


### PR DESCRIPTION
This is still not perfect since we have to copy the file when using this package, but at least it makes it possible to use it in Electron environment without having to download it from untrusted sources.