### PR TITLE
ImageRenderer: call fileLoaderComplete when image has been decoded

### DIFF
--- a/src/components/LoadingTimout.tsx
+++ b/src/components/LoadingTimout.tsx
@@ -21,15 +21,17 @@ export const LoadingTimeout: FC<PropsWithChildren> = ({ children }) => {
       },
       typeof config?.loadingRenderer?.showLoadingTimeout === "number"
         ? config.loadingRenderer.showLoadingTimeout
-        : 500,
+        : 200,
     );
 
     return () => clearTimeout(timeoutRef)
-  }, [config?.loadingRenderer?.showLoadingTimeout]);
+  }, [config?.loadingRenderer?.showLoadingTimeout])
 
-  if (!shouldLoadingRender) {
-    return null;
-  }
-
-  return <>{children}</>;
-};
+  // Simple set the loading components'visibility to hidden and don't hide them:
+  // this prevents a reflow when the loader appears.
+  return <div style={{
+    visibility: !shouldLoadingRender ? 'hidden' : 'visible',
+    display: 'flex',
+    alignContent: 'center'
+  }}>{children}</div>
+}

--- a/src/renderers/imageProxy/index.tsx
+++ b/src/renderers/imageProxy/index.tsx
@@ -14,7 +14,7 @@ const ImageProxyRenderer: DocRenderer = (props) => {
   return (
     <Container id="image-renderer" {...rest}>
       {children || (
-        <Img id="image-img" src={currentDocument.fileData as string} />
+        <Img id="image-img" src={currentDocument.uri} />
       )}
     </Container>
   );

--- a/src/renderers/images/index.tsx
+++ b/src/renderers/images/index.tsx
@@ -26,5 +26,13 @@ const ImagesRenderer: DocRenderer = (props) => <StyledImageRenderer {...props} /
 
 ImagesRenderer.fileTypes = ["png", "gif", "jpg", "jpeg", "bmp", "webp", "svg", "image/png", "image/gif", "image/jpg", "image/jpeg", "image/bmp", "image/webp", "image/svg+xml"];
 ImagesRenderer.weight = 0;
-
+ImagesRenderer.fileLoader = ({ fileLoaderComplete, documentURI }) => {
+  const img = new Image()
+  img.onload = () => {
+    fileLoaderComplete({
+      result: null
+    }  as FileReader)
+  }
+  img.src = documentURI
+}
 export default ImagesRenderer;

--- a/src/store/DocViewerProvider.tsx
+++ b/src/store/DocViewerProvider.tsx
@@ -77,7 +77,7 @@ const DocViewerProvider = forwardRef<
     if (activeDocument) {
       dispatch(updateCurrentDocument(activeDocument))
     }
-  }, [activeDocument])
+  }, [activeDocument?.uri])
   
   useImperativeHandle(
     ref,

--- a/src/utils/fileLoaders.ts
+++ b/src/utils/fileLoaders.ts
@@ -1,20 +1,20 @@
 export interface FileLoaderFuncProps {
-  documentURI: string;
-  signal: AbortSignal;
-  fileLoaderComplete: FileLoaderComplete;
-  headers?: Record<string, string>;
+  documentURI: string
+  signal: AbortSignal
+  fileLoaderComplete: FileLoaderComplete
+  headers?: Record<string, string>
 }
 
-export type FileLoaderComplete = (fileReader?: FileReader) => void;
-export type FileLoaderFunction = (props: FileLoaderFuncProps) => void;
+export type FileLoaderComplete = (fileReader?: FileReader) => void
+export type FileLoaderFunction = (props: FileLoaderFuncProps) => void
 
-type ReaderTypeFunction = "dataURL" | "arrayBuffer" | "binaryString" | "text";
+type ReaderTypeFunction = "dataURL" | "arrayBuffer" | "binaryString" | "text"
 
 interface BaseFileLoaderFuncOptions extends FileLoaderFuncProps {
-  readerTypeFunction: ReaderTypeFunction;
+  readerTypeFunction: ReaderTypeFunction
 }
 
-type BaseFileLoaderFunction = (props: BaseFileLoaderFuncOptions) => void;
+type BaseFileLoaderFunction = (props: BaseFileLoaderFuncOptions) => void
 
 const _fileLoader: BaseFileLoaderFunction = ({
   documentURI,
@@ -25,50 +25,48 @@ const _fileLoader: BaseFileLoaderFunction = ({
 }) => {
   return fetch(documentURI, { signal, headers })
     .then(async (res) => {
-      const blob = await res.blob();
+      const blob = await res.blob()
 
-      const fileReader = new FileReader();
-      fileReader.addEventListener("loadend", () =>
-        fileLoaderComplete(fileReader),
-      );
+      const fileReader = new FileReader()
+      fileReader.addEventListener("loadend", () => fileLoaderComplete(fileReader))
 
       switch (readerTypeFunction) {
         case "arrayBuffer":
-          fileReader.readAsArrayBuffer(blob);
-          break;
+          fileReader.readAsArrayBuffer(blob)
+          break
         case "binaryString":
-          fileReader.readAsBinaryString(blob);
-          break;
+          fileReader.readAsBinaryString(blob)
+          break
         case "dataURL":
-          fileReader.readAsDataURL(blob);
-          break;
+          fileReader.readAsDataURL(blob)
+          break
         case "text":
-          fileReader.readAsText(blob);
-          break;
+          fileReader.readAsText(blob)
+          break
 
         default:
-          break;
+          break
       }
     })
     .catch((e) => {
-      return e;
-    });
-};
+      return e
+    })
+}
 
 export const arrayBufferFileLoader: FileLoaderFunction = (props) => {
-  return _fileLoader({ ...props, readerTypeFunction: "arrayBuffer" });
-};
+  return _fileLoader({ ...props, readerTypeFunction: "arrayBuffer" })
+}
 
 export const dataURLFileLoader: FileLoaderFunction = (props) => {
-  return _fileLoader({ ...props, readerTypeFunction: "dataURL" });
-};
+  return _fileLoader({ ...props, readerTypeFunction: "dataURL" })
+}
 
 export const textFileLoader: FileLoaderFunction = (props) => {
-  return _fileLoader({ ...props, readerTypeFunction: "text" });
-};
+  return _fileLoader({ ...props, readerTypeFunction: "text" })
+}
 
 export const binaryStringFileLoader: FileLoaderFunction = (props) => {
-  return _fileLoader({ ...props, readerTypeFunction: "binaryString" });
-};
+  return _fileLoader({ ...props, readerTypeFunction: "binaryString" })
+}
 
-export const defaultFileLoader = dataURLFileLoader;
+export const defaultFileLoader = dataURLFileLoader


### PR DESCRIPTION
Previously the file was fetched, then the loader was complete, but since we were using the data-url form as source this could take a while before the image was decoded. And during this time no loader was displayed since it was considered loaded.

Also improved the loader so that it doesn't cause a reflow when the loader appears and reduced the delay before the spinner is displayed.